### PR TITLE
Add another Prismic#documents clause for "option tags"

### DIFF
--- a/lib/prismic.ex
+++ b/lib/prismic.ex
@@ -103,6 +103,22 @@ defmodule Prismic do
     end
   end
 
+  @doc """
+  Search for all documents matching the `type` and all `required_tags`, plus
+  **at least one** of the `option_tags`.
+  """
+  def documents(%{type: type, required_tags: required_tags, option_tags: option_tags}, opts) do
+    with {:ok, search_form} <- everything_search_form(opts) do
+      search_form
+      |> SearchForm.set_query_predicates([
+        Predicate.at("document.type", type),
+        Predicate.at("document.tags", required_tags),
+        Predicate.any("document.tags", option_tags)
+      ])
+      |> submit_and_extract_results()
+    end
+  end
+
   def documents(
         %{
           type: type,


### PR DESCRIPTION
The idea is that, if you know a document contains one of a short list of tags -- say, the taxons of a product -- then you can query for all of the tags and get back any documents which contain at least one of them. So if I want to look for Prismic documents that I should show for a pair of women's jeans, I'll look for `women` and `women/clothing` and `women/clothing/jeans`.

**Caveats**
- This approach assumes that, if merch defines different documents for `women` and `women/clothing/jeans`, then we'll want to display *both* of them on a women's jeans page.
  - If y'all think that we will instead want to display only the most specific one, then this method is unnecessary. We query one of the existing `documents` clauses multiple times, starting with `women/clothing/jeans`, then `women/clothing`, then `women`, stopping whenever we get a document.
  - On the other hand, maybe it would be more performant to keep the method in this PR, and have the client iterate through the results to decide which document to display.
- I'm pretty sure `option_tags` is not the best name for this concept. I didn't want it to be `optional_tags` since the tags aren't optional -- the document has to contain at least one of them. They are "options" in the sense that the document can "choose" any one of them to list as a tag. They're more like "possible tags?" "at-least-one tags?" I don't know.