### PR TITLE
cache search form submitting

### DIFF
--- a/lib/prismic.ex
+++ b/lib/prismic.ex
@@ -203,12 +203,14 @@ defmodule Prismic do
   end
 
   defp submit_and_extract_results(%SearchForm{} = search_form) do
-    case SearchForm.submit(search_form) do
-      {:ok, response} ->
-        {:ok, Map.get(response, :results, [])}
+    Cache.get_or_store(inspect(search_form), fn ->
+      case SearchForm.submit(search_form) do
+        {:ok, response} ->
+          {:ok, Map.get(response, :results, [])}
 
-      {:error, _response} = response ->
-        response
-    end
+        {:error, _response} = response ->
+          response
+      end
+    end)
   end
 end


### PR DESCRIPTION
a simple way to add a cache to the library's document requests, the basic cache that is in the library would eventually use too much memory and become a bottleneck as it resides in a single genserver, but there is a behaviour to write an adapter for another cache ( or of course it is possible to improve the built in cache )