### PR TITLE
[#161496734] - Provide default sort order for documents

### DIFF
--- a/lib/prismic.ex
+++ b/lib/prismic.ex
@@ -187,12 +187,16 @@ defmodule Prismic do
   def everything_search_form(opts \\ %{}) do
     with {:ok, api} <- api(opts[:repo_url] || repo_url()),
          %Ref{} = ref <- opts[:ref] || API.find_ref(api, "Master"),
-         %SearchForm{} = search_form <- SearchForm.from_api(api) do
+         %SearchForm{} = search_form <- SearchForm.from_api(api),
+         orderings <- opts[:orderings]
+        do
       search_form =
         if token = opts[:preview_token] do
           SearchForm.set_data_field(search_form, :ref, token)
         else
-          SearchForm.set_ref(search_form, ref)
+          search_form
+          |> SearchForm.set_ref(ref)
+          |> SearchForm.set_orderings(orderings)
         end
 
       {:ok, search_form}

--- a/lib/search_form.ex
+++ b/lib/search_form.ex
@@ -56,6 +56,7 @@ defmodule Prismic.SearchForm do
   @spec submit(SearchForm.t()) :: {:ok, any}
   def submit(%SearchForm{form: %Form{action: action}, data: data = %{:ref => ref}})
       when not is_nil(ref) do
+
     params =
       data
       |> Enum.map(fn {k, v} -> {k, finalize_query(v)} end)
@@ -94,6 +95,16 @@ defmodule Prismic.SearchForm do
         # TODO: create an exception type
         raise "ref #{ref_label} not found!"
     end
+  end
+
+  def set_orderings(%SearchForm{} = search_form, nil) do
+    set_data_field(search_form, :orderings, "[document.last_publication_date desc]")
+  end
+  def set_orderings(%SearchForm{} = search_form, "") do
+    set_data_field(search_form, :orderings, "[document.last_publication_date desc]")
+  end
+  def set_orderings(%SearchForm{} = search_form, order) do
+    set_data_field(search_form, :orderings, order)
   end
 
   # @spec set_predicates(Form.t, [Prismic.Predicate.t])

--- a/test/search_form_test.exs
+++ b/test/search_form_test.exs
@@ -53,6 +53,29 @@ defmodule Prismic.SearchFormTest do
     end
   end
 
+  describe "set_orderings/2" do
+    test "sets the given ordering" do
+      search_form = SearchForm.from_api(@api, :arguments, %{:q => "eggs"})
+
+      orderings = SearchForm.set_orderings(search_form, "[document.first_publication_date]")
+      assert orderings.data[:orderings] == "[document.first_publication_date]"
+    end
+
+    test "sets the default ordering if it receives blank" do
+      search_form = SearchForm.from_api(@api, :arguments, %{:q => "eggs"})
+
+      orderings = SearchForm.set_orderings(search_form, "")
+      assert orderings.data[:orderings] == "[document.last_publication_date desc]"
+    end
+
+    test "sets the default ordering if it receives nil" do
+      search_form = SearchForm.from_api(@api, :arguments, %{:q => "eggs"})
+
+      orderings = SearchForm.set_orderings(search_form, nil)
+      assert orderings.data[:orderings] == "[document.last_publication_date desc]"
+    end
+  end
+
   describe "finalize_query/1" do
     import SearchForm, only: [finalize_query: 1]
     test "makes string version of a list" do


### PR DESCRIPTION
## Description

We have today multiple queries made where we only want the most recent document returned from Prismic, but we found that not always the first one we get is the most recent one. 

We need to make sure we're actually ordering the queries by descending `last_publication_date`, which is the ideal order we expect.

[API's Prismic ordering support](https:/prismic.io/docs/rest-api/query-the-api/order-your-results).

## Goal

This PR has the goal to add the ability of using the `oderings` support from Prismic. This way we can specify which order we want from the api repo or use a default one to return the desired list of documents.

## Testing if you're a TRR employee

To test it locally you have to do some steps to make it work:
- Go to the `prismic-elixir` project and put int the config file this code: 
```elixir
config :prismic,
    repo_url: "https://micro.cdn.prismic.io/api"
```
- Go to your `api` repository and set this changes your `mix.exs`file to point to correct branch to test:
```
{:prismic, git: "https://github.com/TheRealReal/prismic-elixir", branch: "csa/161496734/bug/add-orderings-support"}
```
- Now run the app by setting these env too:
```
 CMS_HTTP_TIMEOUT=2000 CMS_HTTP_RECV_TIMEOUT=2000 PORT=4001 mix phx.server
```
- Open a request IDE you prefer to use like to the GraphQL query to this endpoint: `http://localhost:4001`. 
- Do a query to search and make sure the list of documents is returning in the correct order.
- You can choose another query for a different list if you prefer. 