### PR TITLE
[#163776583] Allow new options, including 'after', 'fetchLinks', 'page', and 'pageSize'

### DIFF
--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -27,7 +27,6 @@ defmodule Prismic.Parser do
   alias StructuredText.Span.{Em, Hyperlink, Label, Strong}
 
   require Logger
-  require IEx
 
   @parsers %{
     "Color" => :parse_color,

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -27,6 +27,7 @@ defmodule Prismic.Parser do
   alias StructuredText.Span.{Em, Hyperlink, Label, Strong}
 
   require Logger
+  require IEx
 
   @parsers %{
     "Color" => :parse_color,
@@ -104,7 +105,7 @@ defmodule Prismic.Parser do
         %{value: %{document: %{slug: slug, type: doc_type, data: doc_data} = doc} = value} = _json
       ) do
     fragments =
-      if raw_frags = doc_data[doc_type] do
+      if raw_frags = doc_data[String.to_atom(doc_type)] do
         for {name, raw_fragment} <- raw_frags, do: {name, parse_fragment(raw_fragment)}
       end
 
@@ -155,10 +156,10 @@ defmodule Prismic.Parser do
   def parse_group(%{type: "Group", value: groups}) do
     group_docs =
       Enum.map(groups, fn group ->
-        fragments = for {name, raw_fragment} <- group,
-        into: %{} do
-          {name, parse_fragment(raw_fragment)}
-        end
+        fragments =
+          for {name, raw_fragment} <- group, into: %{} do
+            {name, parse_fragment(raw_fragment)}
+          end
 
         %GroupDocument{fragments: fragments}
       end)
@@ -373,5 +374,6 @@ defmodule Prismic.Parser do
       {:error, _} -> nil
     end
   end
+
   defp parse_pub_date(nil), do: nil
 end

--- a/lib/prismic.ex
+++ b/lib/prismic.ex
@@ -1,6 +1,6 @@
 defmodule Prismic do
   require Logger
-  alias Prismic.{API, Cache, Document, Predicate, Ref, SearchForm}
+  alias Prismic.{API, Cache, Document, Predicate, SearchForm}
 
   defp repo_url, do: Application.get_env(:prismic, :repo_url)
 
@@ -184,25 +184,19 @@ defmodule Prismic do
     end
   end
 
+  @spec everything_search_form(map()) :: {:ok, SearchForm.t()} | {:error, any()}
   def everything_search_form(opts \\ %{}) do
-    with {:ok, api} <- api(opts[:repo_url] || repo_url()),
-         %Ref{} = ref <- opts[:ref] || API.find_ref(api, "Master"),
-         %SearchForm{} = search_form <- SearchForm.from_api(api),
-         orderings <- opts[:orderings]
-        do
-      search_form =
-        if token = opts[:preview_token] do
-          SearchForm.set_data_field(search_form, :ref, token)
-        else
-          search_form
-          |> SearchForm.set_ref(ref)
-          |> SearchForm.set_orderings(orderings)
-        end
+    repo_url = opts[:repo_url] || repo_url()
 
+    with {:ok, api} <- api(repo_url),
+         %SearchForm{} = search_form <- SearchForm.from_api(api, :everything, opts) do
       {:ok, search_form}
     else
       {:error, _error} = error ->
         error
+
+      nil ->
+        {:error, "No `:everything` form available for #{repo_url}"}
     end
   end
 

--- a/lib/search_form.ex
+++ b/lib/search_form.ex
@@ -66,6 +66,7 @@ defmodule Prismic.SearchForm do
   @spec submit(SearchForm.t()) :: {:ok, any}
   def submit(%SearchForm{form: %Form{action: action}, data: data = %{:ref => ref}})
       when not is_nil(ref) do
+
     params =
       data
       |> Enum.map(fn {k, v} -> {k, finalize_query(v)} end)
@@ -75,13 +76,10 @@ defmodule Prismic.SearchForm do
       {:ok, %{body: body, status_code: status_code}} when status_code >= 400 ->
         Logger.error(body)
         {:error, body}
-
       {:ok, %{body: body, status_code: status_code}} when status_code >= 200 ->
-        response =
-          body
-          |> Poison.decode!(keys: :atoms)
-          |> Parser.parse_response()
-
+        response = body
+        |> Poison.decode!(keys: :atoms)
+        |> Parser.parse_response()
         {:ok, response}
 
       {:error, _error} = error ->
@@ -98,7 +96,6 @@ defmodule Prismic.SearchForm do
   def set_ref(search_form = %SearchForm{}, %Ref{ref: ref}) do
     set_data_field(search_form, :ref, ref)
   end
-
   def set_ref(search_form = %SearchForm{api: api = %API{}}, ref_label) do
     case API.find_ref(api, ref_label) do
       %Ref{ref: ref} ->
@@ -113,11 +110,9 @@ defmodule Prismic.SearchForm do
   def set_orderings(%SearchForm{} = search_form, nil) do
     set_data_field(search_form, :orderings, "[document.last_publication_date desc]")
   end
-
   def set_orderings(%SearchForm{} = search_form, "") do
     set_data_field(search_form, :orderings, "[document.last_publication_date desc]")
   end
-
   def set_orderings(%SearchForm{} = search_form, order) do
     set_data_field(search_form, :orderings, order)
   end

--- a/lib/search_form.ex
+++ b/lib/search_form.ex
@@ -26,16 +26,9 @@ defmodule Prismic.SearchForm do
       |> build_default_data()
       |> Map.merge(data)
 
-    ref =
-      cond do
-        preview_token = data[:preview_token] -> %Ref{ref: preview_token}
-        ref_label = data[:ref] -> ref_label
-        true -> "Master"
-      end
-
     struct(__MODULE__, api: api, form: form, data: data)
     |> set_orderings(data[:orderings])
-    |> set_ref(ref)
+    |> set_ref_from_data()
   end
 
   @doc """
@@ -140,4 +133,19 @@ defmodule Prismic.SearchForm do
   @doc "we must make a query string friendly version of a prismic query list, other data types are query encodable already"
   def finalize_query(query) when is_list(query), do: "[#{query}]"
   def finalize_query(query), do: query
+
+  # Inside `search_form`'s `data`, convert a preview token or a ref label to a
+  # ref id. Use Master ref as default.
+  @spec set_ref_from_data(t) :: t
+  defp set_ref_from_data(%{data: %{preview_token: token}} = search_form) when token != nil do
+    set_data_field(search_form, :ref, token)
+  end
+
+  defp set_ref_from_data(%{data: %{ref: label}} = search_form) when label != nil do
+    set_ref(search_form, label)
+  end
+
+  defp set_ref_from_data(search_form) do
+    set_ref(search_form, "Master")
+  end
 end

--- a/lib/search_form.ex
+++ b/lib/search_form.ex
@@ -14,19 +14,28 @@ defmodule Prismic.SearchForm do
           data: Map.t()
         }
 
-  @spec from_api(API.t(), :everything, Map.t()) :: SearchForm.t() | nil
+  @spec from_api(API.t(), atom(), Map.t()) :: SearchForm.t() | nil
   def from_api(api = %API{forms: forms}, name \\ :everything, data \\ %{}) do
     if form = forms[name], do: SearchForm.new(api, form, data)
   end
 
   @spec new(API.t(), Form.t(), Map.t()) :: t()
   def new(api, form = %Form{fields: fields}, data \\ %{}) do
-    default_data =
+    data =
       fields
       |> build_default_data()
       |> Map.merge(data)
 
-    struct(__MODULE__, api: api, form: form, data: default_data)
+    ref =
+      cond do
+        preview_token = data[:preview_token] -> %Ref{ref: preview_token}
+        ref_label = data[:ref] -> ref_label
+        true -> "Master"
+      end
+
+    struct(__MODULE__, api: api, form: form, data: data)
+    |> set_orderings(data[:orderings])
+    |> set_ref(ref)
   end
 
   @doc """

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -1,6 +1,9 @@
 defmodule Prismic.ParserTest do
   use ExUnit.Case
 
+  alias Prismic.Fragment.{DocumentLink, StructuredText, Text, WebLink}
+  alias Prismic.Parser
+
   describe "parsing web links" do
     test "parses web link within structured text" do
       text = %{
@@ -21,16 +24,16 @@ defmodule Prismic.ParserTest do
         ]
       }
 
-      parsed = Prismic.Parser.parse_structured_text(text)
+      parsed = Parser.parse_structured_text(text)
 
-      assert parsed == %Prismic.Fragment.StructuredText{
+      assert parsed == %StructuredText{
                blocks: [
-                 %Prismic.Fragment.StructuredText.Block.Text.Paragraph{
+                 %StructuredText.Block.Text.Paragraph{
                    label: nil,
                    spans: [
-                     %Prismic.Fragment.StructuredText.Span.Hyperlink{
+                     %StructuredText.Span.Hyperlink{
                        end: 0,
-                       link: %Prismic.Fragment.WebLink{target: nil, url: "https://prismic.io"},
+                       link: %WebLink{target: nil, url: "https://prismic.io"},
                        start: 4
                      }
                    ],
@@ -43,12 +46,67 @@ defmodule Prismic.ParserTest do
     test "parses http link fragments" do
       parsed =
         %{type: "Link.web", value: %{url: "https://general.com"}}
-        |> Prismic.Parser.parse_web_link()
+        |> Parser.parse_web_link()
 
-      assert parsed == %Prismic.Fragment.WebLink{
+      assert parsed == %WebLink{
                target: nil,
                url: "https://general.com"
              }
+    end
+  end
+
+  @prismic_document_link %{
+    type: "Link.document",
+    value: %{
+      document: %{
+        id: "XBLlVREAACsA5_9J",
+        type: "measurement",
+        tags: [],
+        lang: "en-us",
+        slug: "womens-shoulder"
+      },
+      isBroken: false
+    }
+  }
+
+  @parsed_document_link %DocumentLink{
+    broken: false,
+    id: "XBLlVREAACsA5_9J",
+    lang: "en-us",
+    slug: "womens-shoulder",
+    tags: [],
+    target: nil,
+    type: "measurement",
+    uid: nil
+  }
+
+  describe "parse_document_link/1" do
+    test "translates Prismic v1 response format into DocumentLink struct" do
+      assert Parser.parse_document_link(@prismic_document_link) == @parsed_document_link
+    end
+
+    test "includes fragments in DocumentLink when Prismic responseincludes linked data" do
+      prismic_data = %{
+        measurement: %{
+          description: %{
+            type: "Text",
+            value: "Measured across the back, from shoulder seam to shoulder seam."
+          }
+        }
+      }
+
+      parsed_fragments = [
+        description: %Text{
+          value: "Measured across the back, from shoulder seam to shoulder seam."
+        }
+      ]
+
+      prismic_link_with_data =
+        put_in(@prismic_document_link, [:value, :document, :data], prismic_data)
+
+      parsed_link_with_data = Map.put(@parsed_document_link, :fragments, parsed_fragments)
+
+      assert Parser.parse_document_link(prismic_link_with_data) == parsed_link_with_data
     end
   end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -85,7 +85,7 @@ defmodule Prismic.ParserTest do
       assert Parser.parse_document_link(@prismic_document_link) == @parsed_document_link
     end
 
-    test "includes fragments in DocumentLink when Prismic responseincludes linked data" do
+    test "includes fragments in DocumentLink when Prismic response includes linked data" do
       prismic_data = %{
         measurement: %{
           description: %{

--- a/test/prismic_test.exs
+++ b/test/prismic_test.exs
@@ -32,14 +32,10 @@ defmodule Prismic.Test do
   end
 
   describe "everything_search_form/1" do
-    test "sets master ref by default" do
-      {:ok, %{data: %{ref: ref}, api: %{refs: [%{ref: master_ref}]}}} = Prismic.everything_search_form()
-      assert ref == master_ref
-    end
-
-    test "sets preview token as ref if one given" do
-      {:ok, %{data: %{ref: ref}}} = Prismic.everything_search_form(%{preview_token: "yo"})
-      assert ref == "yo"
+    test "uses repo_url from configuration if none is given" do
+      configured_repo_url = Application.get_env(:prismic, :repo_url)
+      {:ok, search_form} = Prismic.everything_search_form(%{})
+      assert search_form.api.repository_url == configured_repo_url
     end
   end
 end

--- a/test/prismic_test.exs
+++ b/test/prismic_test.exs
@@ -30,12 +30,4 @@ defmodule Prismic.Test do
       {:error, _error} = Prismic.all()
     end
   end
-
-  describe "everything_search_form/1" do
-    test "uses repo_url from configuration if none is given" do
-      configured_repo_url = Application.get_env(:prismic, :repo_url)
-      {:ok, search_form} = Prismic.everything_search_form(%{})
-      assert search_form.api.repository_url == configured_repo_url
-    end
-  end
 end


### PR DESCRIPTION
<!-- ↑ Provide a general summary of your changes in the Title above ↑ -->
<!-- ↑ with the pivotal ticket id. ↑ -->
<!-- ↑ [#TICKET_ID] My awesome pull request title ↑ -->

<!-- Add a link for pivotal tracker -->
[PT-#163776583](https://www.pivotaltracker.com/story/show/163776583)

## Description
`Prismic.everything_search_form/1`, `Prismic.all/1`, and `Prismic.documents/2` now support passing arbitrary parameters to Prismic.

In particular, we can now use the pagination params `after`, `page`, and `pageSize`, as well as `fetchLinks`.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Clients can use [paginated results](https://prismic.io/docs/rest-api/query-the-api/pagination-for-results). They can also get more use out of [linked documents](https://prismic.io/docs/rest-api/query-the-api/fetch-linked-document-fields), since they can get some fields from linked documents without needing to make an extra request.

## Testing
- Use this branch locally
- Edit `dev.exs` to use your repo URL: `config :prismic, repo_url: "<YOUR URL HERE>"`
- Run `iex -S mix`
- Make some requests that use the pagination parameters:
  - `pageSize` is the number of results that will be returned
  - `page` is the page number that you're on (1 for the first page)
  - `after` is the ID of a document; Prismic will only start counting results after that document
  - So one example query is `Prismic.all(%{after: "<SOME ID HERE>", page: "1", pageSize: "5"})`
- To see `fetchLinks` in action, you'll need to get documents that link to other Prismic documents.
  - `fetchLinks` uses the same syntax as it does in [Prismic's API](https://prismic.io/docs/rest-api/query-the-api/fetch-linked-document-fields)
  - For TRR users, one example is `Prismic.documents(%{type: "taxon-size-group"}, %{fetchLinks: "measurement.display_name,measurement.description"})`

## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- Put an `[x]` in any of the boxes that apply: -->
- [ ] Bug fix _(a non-breaking change which fixes an issue)_
- [x] New feature _(a non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that changes existing functionality)_
- [ ] Bump dependencies
- [ ] Automated Testing / Missing tests
- [ ] Documentation

## Checklist:
<!-- Verify the following points and put an `[x]` in the boxes that apply: -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Yes, I have added tests to cover my changes.
- [ ] No, We don't have a test suite in this project yet.
- [ ] My change requires a change to the documentation.
- [ ] My change requires release strategy _(uncomment the Release strategy below)_

<!-- ## Release strategy -->
<!-- Describe PR dependecies, migration, vcl change, and rake tasks that need to be executed -->

<!-- At mention person or team responsible for reviewing proposed changes. -->
<!-- ex: cc/ @TheRealReal/buyer -->
cc/ @TheRealReal/buyer-purchase 
