### PR TITLE
[#164177075] Only try to send parameters that Prismic will accept

### DIFF
--- a/lib/search_form.ex
+++ b/lib/search_form.ex
@@ -14,6 +14,19 @@ defmodule Prismic.SearchForm do
           data: Map.t()
         }
 
+  @valid_query_params ~w(
+    access_token
+    after
+    fetch
+    fetchLinks
+    lang
+    orderings
+    page
+    pageSize
+    q
+    ref
+  )a
+
   @spec from_api(API.t(), atom(), Map.t()) :: SearchForm.t() | nil
   def from_api(api = %API{forms: forms}, name \\ :everything, data \\ %{}) do
     if form = forms[name], do: SearchForm.new(api, form, data)
@@ -59,9 +72,9 @@ defmodule Prismic.SearchForm do
   @spec submit(SearchForm.t()) :: {:ok, any}
   def submit(%SearchForm{form: %Form{action: action}, data: data = %{:ref => ref}})
       when not is_nil(ref) do
-
     params =
       data
+      |> Enum.filter(fn {key, _value} -> key in @valid_query_params end)
       |> Enum.map(fn {k, v} -> {k, finalize_query(v)} end)
       |> Enum.into([])
 
@@ -69,10 +82,13 @@ defmodule Prismic.SearchForm do
       {:ok, %{body: body, status_code: status_code}} when status_code >= 400 ->
         Logger.error(body)
         {:error, body}
+
       {:ok, %{body: body, status_code: status_code}} when status_code >= 200 ->
-        response = body
-        |> Poison.decode!(keys: :atoms)
-        |> Parser.parse_response()
+        response =
+          body
+          |> Poison.decode!(keys: :atoms)
+          |> Parser.parse_response()
+
         {:ok, response}
 
       {:error, _error} = error ->
@@ -89,6 +105,7 @@ defmodule Prismic.SearchForm do
   def set_ref(search_form = %SearchForm{}, %Ref{ref: ref}) do
     set_data_field(search_form, :ref, ref)
   end
+
   def set_ref(search_form = %SearchForm{api: api = %API{}}, ref_label) do
     case API.find_ref(api, ref_label) do
       %Ref{ref: ref} ->
@@ -103,9 +120,11 @@ defmodule Prismic.SearchForm do
   def set_orderings(%SearchForm{} = search_form, nil) do
     set_data_field(search_form, :orderings, "[document.last_publication_date desc]")
   end
+
   def set_orderings(%SearchForm{} = search_form, "") do
     set_data_field(search_form, :orderings, "[document.last_publication_date desc]")
   end
+
   def set_orderings(%SearchForm{} = search_form, order) do
     set_data_field(search_form, :orderings, order)
   end


### PR DESCRIPTION
<!-- ↑ Provide a general summary of your changes in the Title above ↑ -->
<!-- ↑ with the pivotal ticket id. ↑ -->
<!-- ↑ [#TICKET_ID] My awesome pull request title ↑ -->

<!-- Add a link for pivotal tracker -->
[PT-#164177075](https://www.pivotaltracker.com/story/show/164177075)

## Description
When we forward parameters from `SearchForm.submit/1` (or, more generally, `Prismic.documents/2`) to Prismic, only forward the parameters that we know Prismic will accept. 

Currently these are:
- `access_token`
- `after`
- `fetch`
- `fetchLinks`
- `lang`
- `orderings`
- `page`
- `pageSize`
- `q`
- `ref`

Reviewers, most of the new code is in tests -- please let me know if you like my setup with the custom HTTPClient there, or if you think we should take a different approach.

## Motivation and Context
Reduces the likelihood of #18 being a breaking change. More specifically, our own client of this library was trying to send parameters that were unserializable, which caused the request to fail. Clients could still send unserializable parameters, but they're much less likely to do so when we only use parameters that actually make sense to Prismic.

## Testing
- With just this library:
  - Run this branch and add a repo_url to your dev config, like `config :prismic, repo_url: "https://micro.cdn.prismic.io/api"`
  - Ask for documents with options including a keyword list, like `Prismic.documents(%{type: "document_type"}, %{fake_option: [blah: []]}`
  - Check that the query doesn't crash
- As a TRR employee, with our API:
  - In the `mix.exs` for the CMS app, edit the Prismic dependency to point to this branch
  - `mix deps.update`
  - Run the query
  ```
  query categories {
    categories{
      categoryName
      title
    }
  }
  ```
  - Ensure that the titles don't include the word "fallback"


## Type of Changes
<!-- What type of changes does your code introduce? -->
<!-- Put an `[x]` in any of the boxes that apply: -->
- [x] Bug fix _(a non-breaking change which fixes an issue)_
- [ ] New feature _(a non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that changes existing functionality)_
- [ ] Bump dependencies
- [ ] Automated Testing / Missing tests
- [ ] Documentation

## Checklist:
<!-- Verify the following points and put an `[x]` in the boxes that apply: -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Yes, I have added tests to cover my changes.
- [ ] No, We don't have a test suite in this project yet.
- [ ] My change requires a change to the documentation.
- [ ] My change requires release strategy _(uncomment the Release strategy below)_

## Release strategy
<!-- Describe PR dependecies, migration, vcl change, and rake tasks that need to be executed -->
As always we'll need to update the API to use the new version of this library after merging this.

<!-- At mention person or team responsible for reviewing proposed changes. -->
<!-- ex: cc/ @TheRealReal/buyer -->
cc/ @TheRealReal/buyer-purchase 
