### PR TITLE
Fix time unit deprecation warning

### DIFF
--- a/lib/cache.ex
+++ b/lib/cache.ex
@@ -74,5 +74,5 @@ defmodule Prismic.Cache.Default do
     end)
   end
 
-  defp now, do: System.os_time(:seconds)
+  defp now, do: System.os_time(:second)
 end


### PR DESCRIPTION
Elixir 1.8 added this hard-deprecation 
```
[System] :seconds, :milliseconds, etc. as time units is deprecated in favor of :second, :millisecond, etc.
```
(see https://github.com/elixir-lang/elixir/releases/tag/v1.8.0)

which generates this warning

```
warning: deprecated time unit: :seconds. A time unit should be :second,
:millisecond, :microsecond, :nanosecond, or a positive integer
```