### PR TITLE
Change Size on FileLink from Integer to String

### DIFF
--- a/lib/fragment/file_link.ex
+++ b/lib/fragment/file_link.ex
@@ -5,7 +5,7 @@ defmodule Prismic.Fragment.FileLink do
           url: String.t(),
           name: String.t(),
           kind: String.t(),
-          size: Integer.t(),
+          size: String.t(),
           target: String.t()
         }
 end


### PR DESCRIPTION
The JSON response the Prismic API returns encodes this as a String, and we are not doing any type coercion, so this unifies the two.

Additionally, a guess as to why the file size is encoded as string in the JSON: IEEE 754 has a max of around 2e38, and a filesize in bytes may exceed that.