### PR TITLE
Add integration fields parser

### DIFF
--- a/lib/fragment/structured_text/integration_fields.ex
+++ b/lib/fragment/structured_text/integration_fields.ex
@@ -1,0 +1,5 @@
+defmodule Prismic.Fragment.IntegrationFields do
+  @type t :: %__MODULE__{value: Map.t()}
+
+  defstruct [:value]
+end

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -9,6 +9,7 @@ defmodule Prismic.Parser do
     Embed,
     FileLink,
     Geopoint,
+    IntegrationFields,
     Image,
     ImageLink,
     Multiple,
@@ -34,6 +35,7 @@ defmodule Prismic.Parser do
     "Embed" => :parse_embed,
     "GeoPoint" => :parse_geo_point,
     "Group" => :parse_group,
+    "IntegrationFields" => :parse_integration_fields,
     "Image" => :parse_image,
     "Link.web" => :parse_web_link,
     "Multiple" => :parse_multiple,
@@ -375,4 +377,7 @@ defmodule Prismic.Parser do
   end
 
   defp parse_pub_date(nil), do: nil
+
+  def parse_integration_fields(%{type: "IntegrationFields"} = block),
+    do: struct(IntegrationFields, block)
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -1,7 +1,7 @@
 defmodule Prismic.ParserTest do
   use ExUnit.Case
 
-  alias Prismic.Fragment.{DocumentLink, StructuredText, Text, WebLink}
+  alias Prismic.Fragment.{DocumentLink, IntegrationFields, StructuredText, Text, WebLink}
   alias Prismic.Parser
 
   describe "parsing web links" do
@@ -107,6 +107,26 @@ defmodule Prismic.ParserTest do
       parsed_link_with_data = Map.put(@parsed_document_link, :fragments, parsed_fragments)
 
       assert Parser.parse_document_link(prismic_link_with_data) == parsed_link_with_data
+    end
+  end
+
+  @prismic_integration_fields %{
+    type: "IntegrationFields",
+    value: %{
+      a_key: "a value"
+    }
+  }
+
+  @parsed_integration_fields %IntegrationFields{
+    value: %{
+      a_key: "a value"
+    }
+  }
+
+  describe "parse_integration_fields/1" do
+    test "translates Prismic v1 response format into IntegrationFields struct" do
+      assert Parser.parse_integration_fields(@prismic_integration_fields) ==
+               @parsed_integration_fields
     end
   end
 end


### PR DESCRIPTION
Add integration fields parser for prismic's new [integration fields](https://user-guides.prismic.io/en/articles/1401146-introduction-to-integration-fields).

Since `value` in this payload is provided by a webhook (that we can set in prismic), there's no set format to specify with a struct.