### PR TITLE
[#27] Add Boolean Parser

### DIFF
--- a/lib/fragment/boolean.ex
+++ b/lib/fragment/boolean.ex
@@ -1,0 +1,5 @@
+defmodule Prismic.Fragment.Boolean do
+  @type t :: %__MODULE__{value: boolean}
+
+  defstruct [:value]
+end

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -2,6 +2,7 @@ defmodule Prismic.Parser do
   alias Prismic.{AlternateLanguage, Document, Group, GroupDocument, Fragment, Response}
 
   alias Fragment.{
+    Boolean,
     Color,
     CompositeSlice,
     Date,
@@ -30,6 +31,7 @@ defmodule Prismic.Parser do
   require Logger
 
   @parsers %{
+    "Boolean" => :parse_boolean,
     "Color" => :parse_color,
     "Date" => :parse_date,
     "Embed" => :parse_embed,
@@ -55,6 +57,7 @@ defmodule Prismic.Parser do
     defexception message: "Prismic document(s) contain errors"
   end
 
+  @spec parse_document(map) :: Document.t()
   def parse_document(
         %{data: data, first_publication_date: fpd, last_publication_date: lpd} = results_json
       ) do
@@ -93,6 +96,10 @@ defmodule Prismic.Parser do
   end
 
   ## PARSERS
+
+  def parse_boolean(json) do
+    struct(Boolean, json)
+  end
 
   def parse_color(%{type: "Color", value: value}) do
     %Color{value: String.slice(value, 1..-1)}
@@ -202,7 +209,6 @@ defmodule Prismic.Parser do
     Enum.reduce(value, [], fn
       %{value: value, slice_type: type, slice_label: label}, slices ->
         slice = %SimpleSlice{slice_type: type, slice_label: label, value: parse_fragment(value)}
-
         [slice | slices]
 
       %{:"non-repeat" => non_repeat, repeat: repeat} = raw_composite, slices ->

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -1,8 +1,84 @@
 defmodule Prismic.ParserTest do
   use ExUnit.Case
 
-  alias Prismic.Fragment.{DocumentLink, IntegrationFields, StructuredText, Text, WebLink}
-  alias Prismic.Parser
+  alias Prismic.Fragment.{
+    Boolean,
+    CompositeSlice,
+    DocumentLink,
+    IntegrationFields,
+    StructuredText,
+    Text,
+    WebLink
+  }
+
+  alias Prismic.{Document, Parser}
+
+  @sample_document_result %{
+    id: "valid_id",
+    uid: "valid_uid",
+    type: "page",
+    slugs: ["slug1", "slug2"],
+    first_publication_date: "2021-07-16T21:06:13+0000",
+    last_publication_date: "2021-08-23T19:03:34+0000",
+    data: %{
+      page: %{
+        body: %{
+          type: "SliceZone",
+          value: [
+            %{
+              type: "Slice",
+              slice_type: "Carousel",
+              slice_label: nil,
+              repeat: [
+                %{
+                  image: %{
+                    type: "Image",
+                    value: %{
+                      main: %{
+                        dimensions: %{
+                          width: 1200,
+                          height: 600
+                        },
+                        alt: nil,
+                        copyright: nil,
+                        url: "https://images.prismic.io/example-repo/totally-real-image.png"
+                      },
+                      views: %{}
+                    }
+                  }
+                }
+              ],
+              "non-repeat": %{
+                desktop_only: %{
+                  type: "Boolean",
+                  value: false
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  describe "parse_document/1" do
+    test "parses boolean fragments" do
+      assert %Document{
+               fragments: %{
+                 body: [
+                   %CompositeSlice{
+                     non_repeat: %{
+                       desktop_only: %Boolean{
+                         value: false
+                       }
+                     },
+                     repeat: %Prismic.Group{}
+                   }
+                 ]
+               }
+             } = Parser.parse_document(@sample_document_result)
+    end
+  end
 
   describe "parsing web links" do
     test "parses web link within structured text" do


### PR DESCRIPTION
Using this library in production with a boolean field will currently
emit the following warning:

    [warn] Parser for fragment of "Boolean" type not implemented

Add a parser for the boolean fragment.

Closes #27 