### PR TITLE
Replace Travis CI with GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Elixir CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Elixir
+      uses: erlef/setup-beam@v1.9.0
+      with:
+        elixir-version: '1.6'
+        otp-version: '20.0'
+    - name: Restore dependencies cache
+      uses: actions/cache@v2
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-mix-
+    - name: Install dependencies
+      run: mix deps.get
+    - name: Run tests
+      run: mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: elixir
-otp_release:
-  - 20.0
-elixir:
-  - 1.6
-sudo: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Prismic  [![Build Status](https://travis-ci.org/TheRealReal/prismic-elixir.svg?branch=master)](https://travis-ci.org/TheRealReal/prismic-elixir)
+# Prismic ![Build Status Badge](https://github.com/therealreal/prismic-elixir/actions/workflows/ci.yml/badge.svg)
 
 This is an Elixir-based SDK for Prismic.io
   Mostly based on https://github.com/prismicio/ruby-kit and https://github.com/prismicio/javascript-kit


### PR DESCRIPTION
We don't currently have CI running on this project. Previously, we used TravisCI, but our setup is no longer up to date.

For convenience sake and also because GitHub Actions is [free for open source](https://github.com/features/actions#pricing-details), add the default Elixir CI pipeline for GitHub Actions.